### PR TITLE
Fix the link to social icons api

### DIFF
--- a/app/assets/stylesheets/icons.scss
+++ b/app/assets/stylesheets/icons.scss
@@ -5,7 +5,7 @@
 }
 
 // Import icon font, I've used Entypo (http://entypo.com/)
-@import url(https://weloveiconfonts.com/api/?family=entypo);
+@import url('//weloveiconfonts.com/api/?family=entypo');
 
 // List of icon unicode symbols from the icon font
 // and background colours for the icons


### PR DESCRIPTION
The link got blocked on heroku. Now instead of http://, try it with only //
this way the protocol doesnt get specified and it would connect properly
